### PR TITLE
Treat rich function type as a functor to eliminate atomic/composed dichotomy

### DIFF
--- a/function/composition.rkt
+++ b/function/composition.rkt
@@ -20,10 +20,7 @@
           [conjoin (variadic-composition/c procedure?)]
           [&& (variadic-composition/c procedure?)]
           [disjoin (variadic-composition/c procedure?)]
-          [|| (variadic-composition/c procedure?)]
-          [function-null (->* ()
-                              (#:compose-with monoid?)
-                              composed-function?)]))
+          [|| (variadic-composition/c procedure?)]))
 
 (define (compose-powers g h composer)
   ;; either or both could be function powers. in that case, the powers
@@ -144,6 +141,3 @@
 
 (define && conjoin)
 (define || disjoin)
-
-(define (function-null #:compose-with [composer usual-composition])
-  (composed-function composer null))

--- a/function/composition.rkt
+++ b/function/composition.rkt
@@ -115,6 +115,9 @@
            (call (~compose-naively composer))]
           [else (call (~compose-by-merging composer))]))
 
+;; this composition interface composes functions using
+;; the provided monoid, and isn't necessarily the usual
+;; function composition, unlike `compose` below.
 (define (compose-functions composer . gs)
   (switch (gs)
           [empty? (function-null #:compose-with composer)]

--- a/function/type/application-scheme/curried.rkt
+++ b/function/type/application-scheme/curried.rkt
@@ -44,7 +44,8 @@
           [make-curried-function (-> b:procedure?
                                      arguments?
                                      symbol?
-                                     curried-function?)]))
+                                     curried-function?)]
+          [empty-curried-function curried-function?]))
 
 (struct curried-function function (f chirality left right kw)
   #:transparent

--- a/function/type/application-scheme/curried.rkt
+++ b/function/type/application-scheme/curried.rkt
@@ -5,7 +5,10 @@
          racket/generic
          racket/hash
          racket/set
-         racket/list
+         (except-in racket/list
+                    first
+                    rest
+                    empty?)
          arguments
          relation/logic
          (prefix-in b: racket/base)
@@ -15,7 +18,12 @@
                   gen:collection
                   gen:sequence
                   gen:countable
-                  sequence?)
+                  collection?
+                  sequence?
+                  conj
+                  first
+                  rest
+                  empty?)
          ionic)
 
 (require "interface.rkt"
@@ -28,18 +36,6 @@
 
 (provide (contract-out
           [struct curried-function
-            ((f procedure?)
-             (chirality symbol?)
-             (left list?)
-             (right list?)
-             (kw hash?))]
-          [struct curried-atomic-function
-            ((f procedure?)
-             (chirality symbol?)
-             (left list?)
-             (right list?)
-             (kw hash?))]
-          [struct curried-composed-function
             ((f procedure?)
              (chirality symbol?)
              (left list?)
@@ -143,10 +139,7 @@
            (let-values ([(before after)
                          (split-at inner-representation
                                    (add1 marker-position))])
-             `(,@before ,args ,@after)))))])
-
-(struct curried-atomic-function curried-function ()
-  #:transparent
+             `(,@before ,args ,@after)))))]
 
   #:methods gen:application-scheme
   [(define (pass this args)
@@ -164,43 +157,12 @@
                              (append (arguments-positional args)
                                      (curried-function-right this))
                              (curried-function-right this))])
-         (curried-atomic-function f
-                                  chirality
-                                  left-args
-                                  right-args
-                                  (hash-union (curried-function-kw this)
-                                              (arguments-keyword args))))))
-   (define (flat-arguments this)
-     (make-arguments (curried-function-positional this)
-                     (curried-function-kw this)))
-   (define (unwrap-application this)
-     (curried-function-f this))])
-
-(struct curried-composed-function curried-function ()
-  #:transparent
-
-  #:methods gen:application-scheme
-  [(define (pass this args)
-     ;; incorporate fresh arguments into the partial application,
-     ;; retaining existing arg positions and appending the fresh ones
-     ;; at the positions implied by the chirality
-     (let ([f (curried-function-f this)]
-           [chirality (curried-function-chirality this)])
-       (let ([left-args (if (eq? chirality 'left)
-                            (append (curried-function-left this)
-                                    (arguments-positional args))
-                            (curried-function-left this))]
-             [right-args (if (eq? chirality 'right)
-                             ;; note order reversed for right args
-                             (append (arguments-positional args)
-                                     (curried-function-right this))
-                             (curried-function-right this))])
-         (curried-composed-function f
-                                    chirality
-                                    left-args
-                                    right-args
-                                    (hash-union (curried-function-kw this)
-                                                (arguments-keyword args))))))
+         (curried-function f
+                           chirality
+                           left-args
+                           right-args
+                           (hash-union (curried-function-kw this)
+                                       (arguments-keyword args))))))
    (define (flat-arguments this)
      (make-arguments (curried-function-positional this)
                      (curried-function-kw this)))
@@ -210,7 +172,12 @@
   #:methods gen:collection
   [(define/generic -conj conj)
    (define (conj self elem)
-     (-conj (curried-function-f self) elem))]
+     (let ([f (curried-function-f self)])
+       (if (collection? f)
+           (struct-copy curried-function self
+                        [f (-conj f elem)])
+           (struct-copy curried-function self
+                        [f (-conj (-conj (function-null) f) elem)]))))]
 
   #:methods gen:sequence
   [(define/generic -empty? empty?)
@@ -218,29 +185,45 @@
    (define/generic -rest rest)
    (define/generic -reverse reverse)
    (define (empty? self)
-     (-empty? (curried-function-f self)))
+     (let ([f (curried-function-f self)])
+       (and (sequence? f)
+            (-empty? f))))
    (define (first self)
-     (let ([f (-first (curried-function-f self))])
+     (let ([f (curried-function-f self)])
        (if (sequence? f)
-           (struct-copy curried-composed-function self
-                        [f #:parent curried-function f])
-           (curried-atomic-function f
-                                    (curried-function-chirality self)
-                                    (curried-function-left self)
-                                    (curried-function-right self)
-                                    (curried-function-kw self)))))
+           (struct-copy curried-function self
+                        [f (-first f)])
+           self)))
    (define (rest self)
-     (make-curried-function (-rest (curried-function-f self))
-                            empty-arguments
-                            (curried-function-chirality self)))
+     (let ([f (curried-function-f self)])
+       (if (sequence? f)
+           (make-curried-function (-rest f)
+                                  empty-arguments
+                                  (curried-function-chirality self))
+           empty-curried-function)))
    (define (reverse self)
-     (struct-copy curried-composed-function self
-                  [f #:parent curried-function (-reverse (curried-function-f self))]))]
+     (let ([f (curried-function-f self)])
+       (if (sequence? f)
+           (struct-copy curried-function self
+                        [f (-reverse f)])
+           self)))]
 
   #:methods gen:countable
   [(define/generic -length length)
    (define (length self)
-     (-length (curried-function-f self)))])
+     (if (eq? self empty-curried-function)
+         0
+         (let ([f (curried-function-f self)])
+           (if (sequence? f)
+               (-length f)
+               1))))])
+
+(define empty-curried-function
+  (curried-function (function-null)
+                    'left
+                    null
+                    null
+                    (hash)))
 
 (define (curried-function-positional f)
   (append (curried-function-left f)
@@ -276,30 +259,34 @@
 ;; function with interfaces it doesn't support, but unfortunately necessitates
 ;; _two_ types for every application scheme, even those defined by users by
 ;; by implementing gen:application-scheme.
+;;   (4) treat the rich function types as a "functor" in the haskell sense
+;; characterized by their providing implementations for the collection,
+;; sequence, and countable interfaces. Application schemes being rich types
+;; implement these interfaces, simply "passing through" the implementation
+;; to the wrapped function if the wrapped function is a rich type as well.
+;; If it isn't, then treat the scheme as a singleton, analogous to a list
+;; of size 1.
+;; This provides the desired functionality and doesn't necessitate the
+;; atomic/composed dichotomy in (3), and though it lifts any function to
+;; sequence/collection types making them more heavyweight than necessary,
+;; it doesn't do so accidentally like (2) where the wrapped functions
+;; could be falsely advertised as sequences, but rather as part of lifting
+;; these functions to the rich type, providing reasonable implementations
+;; for the rich (e.g. sequence) interfaces in all cases.
 ;;
-;; Until a better idea comes along, we implement option (3) here.
+;; We implement option (4) here.
 (define (make-curried-function f args chirality)
   (let ([pos (arguments-positional args)]
-        [kw (arguments-keyword args)]
-        [f-cons (if (sequence? f)
-                    curried-composed-function
-                    curried-atomic-function)])
+        [kw (arguments-keyword args)])
     (switch (f)
       [curried-function?
        (connect [(~> curried-function-chirality
                      (eq? chirality))
                  (call ((esc pass) args))]
-                [else (connect
-                       [sequence?
-                        (pass (struct-copy curried-composed-function
-                                           f
-                                           [chirality #:parent curried-function chirality])
-                              args)]
-                       [else
-                        (pass (struct-copy curried-atomic-function
-                                           f
-                                           [chirality #:parent curried-function chirality])
-                              args)])])]
+                [else (pass (struct-copy curried-function
+                                         f
+                                         [chirality chirality])
+                            args)])]
       [else (if (eq? chirality 'left)
-                (f-cons f 'left pos null kw)
-                (f-cons f 'right null pos kw))])))
+                (curried-function f 'left pos null kw)
+                (curried-function f 'right null pos kw))])))

--- a/function/type/composed.rkt
+++ b/function/type/composed.rkt
@@ -39,6 +39,9 @@
                                         #:compose-with monoid?)
                                        #:rest (listof procedure?)
                                        composed-function?)]
+          [function-null (->* ()
+                              (#:compose-with monoid?)
+                              composed-function?)]
           [apply/steps (unconstrained-domain-> sequence?)])
          usual-composition
          conjoin-composition
@@ -125,6 +128,9 @@
                      (if thread?
                          fs
                          (reverse fs))))
+
+(define (function-null #:compose-with [composer usual-composition])
+  (composed-function composer null))
 
 (define/arguments (apply/steps args)
   (let ([f (first (arguments-positional args))]

--- a/tests/function.rkt
+++ b/tests/function.rkt
@@ -301,7 +301,7 @@
         "application schemes implement rich interfaces"
       (check-true (sequence? (curry add1)))
       (check-true (sequence? (curry (make-composed-function add1 sqr))))
-      (check-false (sequence? (partial add1)))
+      (check-true (sequence? (partial add1)))
       (check-true (sequence? (partial (make-composed-function add1 sqr))))
       (check-false (sequence? (app +)))
       (check-true (sequence? (app (make-composed-function add1 sqr)))))
@@ -410,7 +410,7 @@
       (check-true (sequence? (curry (app +))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (curry (app (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (curry (curryr (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
-      (check-false (sequence? (partial (app +))) "composed application schemes preserve rich semantics")
+      (check-true (sequence? (partial (app +))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (partial (app (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (partial (partialr (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (app (curry +))) "composed application schemes preserve rich semantics")

--- a/tests/function.rkt
+++ b/tests/function.rkt
@@ -303,7 +303,7 @@
       (check-true (sequence? (curry (make-composed-function add1 sqr))))
       (check-true (sequence? (partial add1)))
       (check-true (sequence? (partial (make-composed-function add1 sqr))))
-      (check-false (sequence? (app +)))
+      (check-true (sequence? (app +)))
       (check-true (sequence? (app (make-composed-function add1 sqr)))))
     (test-case
         "partial"
@@ -388,7 +388,7 @@
       (check-exn exn:fail:contract? (thunk ((app = #:key string-upcase "hi" _) #:key string-downcase "HI")) "overriding template not allowed")
       (check-equal? ((app = #:key _ _ "hi") #:key string-upcase "HI") (= #:key string-upcase "hi" "HI"))
       (check-exn exn:fail:contract? (thunk ((app = #:key _ _ "hi") "HI")) "missing keyword arg in template")
-      (check-equal? ((template-atomic-function string-append (list nothing (just "-") nothing) (hash)) "a" "b") "a-b")
+      (check-equal? ((template-function string-append (list nothing (just "-") nothing) (hash)) "a" "b") "a-b")
       (test-case
           "template represents correct arity"
         (check-equal? 3 (arity (app string-append _ _ _))))

--- a/tests/function.rkt
+++ b/tests/function.rkt
@@ -298,8 +298,8 @@
    (test-suite
     "application schemes"
     (test-suite
-        "application schemes preserve interfaces"
-      (check-false (sequence? (curry add1)))
+        "application schemes implement rich interfaces"
+      (check-true (sequence? (curry add1)))
       (check-true (sequence? (curry (make-composed-function add1 sqr))))
       (check-false (sequence? (partial add1)))
       (check-true (sequence? (partial (make-composed-function add1 sqr))))
@@ -407,13 +407,13 @@
       (check-exn exn:fail:contract? (thunk ((curry (app string-append _ "-" _) "a") "b" "c")))
       (check-equal? ((partial (app string-append _ "-" _) "a") "b") "a-b")
       (check-exn exn:fail:contract? (thunk (((partial (app string-append _ "-" _)) "a") "b")) "partial application does not curry")
-      (check-false (sequence? (curry (app +))) "composed application schemes preserve rich semantics")
+      (check-true (sequence? (curry (app +))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (curry (app (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (curry (curryr (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
       (check-false (sequence? (partial (app +))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (partial (app (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (partial (partialr (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
-      (check-false (sequence? (app (curry +))) "composed application schemes preserve rich semantics")
+      (check-true (sequence? (app (curry +))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (app (curry (make-composed-function add1 +)))) "composed application schemes preserve rich semantics")
       (check-true (sequence? (app (app (make-composed-function add1 +)))) "composed application schemes preserve rich semantics"))
     (test-case


### PR DESCRIPTION
Identify the rich function type with the set of interfaces that it must implement (e.g. `gen:collection`, `gen:sequence`, `gen:countable`), decoupling these interfaces from the idea of composition.

Implement the interfaces in application schemes to avoid the atomic/composed dichotomy.
