### PR TITLE
Peg Qi Dependency Version to Fix CI Failure

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -9,7 +9,7 @@
                "threading-lib"
                "mischief"
                "social-contract"
-               "qi-lib"
+               "git://github.com/countvajhula/qi.git?path=qi-lib#v1.0-maintenance"
                "kw-utils"
                "typed-stack"
                "version-case"


### PR DESCRIPTION
### Summary of Changes

CI jobs are failing. This is a PR to fix them.

The problem is that the Qi library was recently upgraded taking advantage of code only present in Racket 8.3+. A maintenance branch was introduced to support older versions of Racket. This PR depends directly on that version via a Git URL, instead of on the latest version on the package catalog, in order to continue supporting older versions of Racket.

**Note**: This will likely mean that the Relation docs will become unavailable and the package will be reported as "failing" on the package catalog, since depending on older versions isn't correctly reported there.

Options once that happens:
1. Either bump relation's dependency to Racket 8.3+ (which seems undesirable - but convenient)
2. Live with the package being reported as failing
3. Migrate to the lib/test/doc package structure so that only lib will fail but docs will build
4. Hope for a fix from the package server

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.
