### PR TITLE
Fix potential conflict with `compose` alias in `racket/base`

### DIFF
--- a/relation-doc/scribblings/composition.scrbl
+++ b/relation-doc/scribblings/composition.scrbl
@@ -1,39 +1,51 @@
 #lang scribble/doc
+@(module for-label racket/base
+   (require relation/composition
+            relation/type
+            relation/logic
+            (only-in relation/function false.)
+            (only-in racket/math sqr)
+            (only-in racket/function thunk*)
+            racket/contract
+            racket/generic
+            racket/set
+            racket/stream
+            racket/undefined
+            racket/match
+            (only-in racket/base
+                     (foldl f:foldl)
+                     (foldr f:foldr)
+                     (append b:append))
+            (only-in data/collection
+                     length
+                     repeat
+                     sequenceof
+                     sequence?
+                     collection?
+                     map
+                     gen:sequence
+                     (foldl d:foldl)
+                     (foldl/steps d:foldl/steps)))
+   (provide (all-from-out relation/composition
+                          relation/type
+                          relation/logic
+                          relation/function
+                          racket/math
+                          racket/function
+                          racket/contract
+                          racket/generic
+                          racket/set
+                          racket/stream
+                          racket/undefined
+                          racket/match
+                          racket/base
+                          data/collection)))
 @require[scribble/manual
          scribble-abbrevs/manual
          scribble/example
          racket/sandbox
          "eval.rkt"
-         @for-label[relation/composition
-                    relation/type
-                    relation/logic
-                    (only-in relation/function false.)
-                    (only-in racket/function thunk*)
-                    racket/generic
-					racket/undefined
-                    racket/match
-                    (except-in racket +
-                                      -
-                                      *
-                                      /
-                                      foldl
-                                      foldr
-                                      length
-                                      append
-                                      map
-                                      sequence?)
-                    (only-in racket (foldl f:foldl)
-                                    (foldr f:foldr)
-                                    (append b:append))
-                    (only-in data/collection length
-                                             repeat
-                                             sequenceof
-                                             sequence?
-                                             collection?
-                                             map
-                                             gen:sequence
-                                             (foldl d:foldl)
-                                             (foldl/steps d:foldl/steps))]]
+         @for-label['for-label]]
 
 @(define eval-for-docs
   (make-eval-for-docs '(require (except-in data/collection


### PR DESCRIPTION
### Summary of Changes

This PR modifies `relation-doc` to avoid potential conflicts caused by the planned addition of `∘` as an alias for `compose` in `racket/base`: https://github.com/racket/racket/pull/5115 .

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
